### PR TITLE
Add netlifys redirect file for 404 error

### DIFF
--- a/src/netlify.toml
+++ b/src/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
## 🚨🤦🏽🚨 *Problem:*

Please describe the problem you're trying to solve
- Netlify was giving 404 page not found error on refresh

## 🌟💡🌟 *Solution:*

How did you solve it?
<!-- Dont forget to close issues -->
- Added netlify.toml file with redirect to 200 status code

## 👁‍👁‍ *Changes:*

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

## 💠✅💠 *CheckList:*

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
